### PR TITLE
Add support for http/s forwarding proxy

### DIFF
--- a/client.go
+++ b/client.go
@@ -255,6 +255,7 @@ func (c *Client) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		"action", "handle",
 		"ctrlMsg", msg,
 	)
+
 	switch msg.Action {
 	case proto.ActionProxy:
 		c.config.Proxy(w, r.Body, msg)

--- a/cmd/tunnel/config.go
+++ b/cmd/tunnel/config.go
@@ -88,6 +88,10 @@ func loadClientConfigFromFile(file string) (*ClientConfig, error) {
 			if err := validateTCP(t); err != nil {
 				return nil, fmt.Errorf("%s %s", name, err)
 			}
+		case proto.HTTPCONNECT:
+			if err := validateHttpConnect(t); err != nil {
+				return nil, fmt.Errorf("%s %s", name, err)
+			}
 		case proto.SNI:
 			if err := validateSNI(t); err != nil {
 				return nil, fmt.Errorf("%s %s", name, err)
@@ -135,6 +139,26 @@ func validateTCP(t *Tunnel) error {
 
 	// unexpected
 
+	if t.Host != "" {
+		return fmt.Errorf("host: unexpected")
+	}
+	if t.Auth != "" {
+		return fmt.Errorf("auth: unexpected")
+	}
+
+	return nil
+}
+
+func validateHttpConnect(t *Tunnel) error {
+	var err error
+	if t.RemoteAddr, err = normalizeAddress(t.RemoteAddr); err != nil {
+		return fmt.Errorf("remote_addr: %s", err)
+	}
+
+	// unexpected
+	if t.Addr != "" {
+		return fmt.Errorf("addr: unexpected")
+	}
 	if t.Host != "" {
 		return fmt.Errorf("host: unexpected")
 	}

--- a/cmd/tunnel/tunnel.go
+++ b/cmd/tunnel/tunnel.go
@@ -17,7 +17,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/cenkalti/backoff"
-	"github.com/mmatczuk/go-http-tunnel"
+	tunnel "github.com/mmatczuk/go-http-tunnel"
 	"github.com/mmatczuk/go-http-tunnel/id"
 	"github.com/mmatczuk/go-http-tunnel/log"
 	"github.com/mmatczuk/go-http-tunnel/proto"
@@ -171,8 +171,9 @@ func tunnels(m map[string]*Tunnel) map[string]*proto.Tunnel {
 func proxy(m map[string]*Tunnel, logger log.Logger) tunnel.ProxyFunc {
 	httpURL := make(map[string]*url.URL)
 	tcpAddr := make(map[string]string)
-
+	forwardAddr := make(map[string]string)
 	for _, t := range m {
+		fmt.Println("Protocol", t.Protocol)
 		switch t.Protocol {
 		case proto.HTTP:
 			u, err := url.Parse(t.Addr)
@@ -182,14 +183,17 @@ func proxy(m map[string]*Tunnel, logger log.Logger) tunnel.ProxyFunc {
 			httpURL[t.Host] = u
 		case proto.TCP, proto.TCP4, proto.TCP6:
 			tcpAddr[t.RemoteAddr] = t.Addr
+		case proto.HTTPCONNECT:
+			forwardAddr[t.RemoteAddr] = t.RemoteAddr
 		case proto.SNI:
 			tcpAddr[t.Host] = t.Addr
 		}
 	}
 
 	return tunnel.Proxy(tunnel.ProxyFuncs{
-		HTTP: tunnel.NewMultiHTTPProxy(httpURL, log.NewContext(logger).WithPrefix("proxy", "HTTP")).Proxy,
-		TCP:  tunnel.NewMultiTCPProxy(tcpAddr, log.NewContext(logger).WithPrefix("proxy", "TCP")).Proxy,
+		HTTP:        tunnel.NewMultiHTTPProxy(httpURL, log.NewContext(logger).WithPrefix("proxy", "HTTP")).Proxy,
+		TCP:         tunnel.NewMultiTCPProxy(tcpAddr, log.NewContext(logger).WithPrefix("proxy", "TCP")).Proxy,
+		HTTPCONNECT: tunnel.NewMultiForwardingProxy(forwardAddr, log.NewContext(logger).WithPrefix("proxy", "FORWAD")).Proxy,
 	})
 }
 

--- a/forwardingproxy.go
+++ b/forwardingproxy.go
@@ -1,0 +1,224 @@
+package tunnel
+
+import (
+	"bufio"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+	"time"
+
+	"github.com/mmatczuk/go-http-tunnel/log"
+	"github.com/mmatczuk/go-http-tunnel/proto"
+)
+
+// ForwardingProxy uses http tunnel.
+type ForwardingProxy struct {
+	// localAddr specifies default TCP address of the local server.
+	localAddr string
+	// localAddrMap specifies mapping from ControlMessage.ForwardedHost to
+	// local server address, keys may contain host and port, only host or
+	// only port. The order of precedence is the following
+	// * host and port
+	// * port
+	// * host
+	localAddrMap map[string]string
+	// logger is the proxy logger.
+	logger              log.Logger
+	AuthUser            string
+	AuthPass            string
+	ForwardingHTTPProxy *httputil.ReverseProxy
+	DestDialTimeout     time.Duration
+	DestReadTimeout     time.Duration
+	DestWriteTimeout    time.Duration
+	ClientReadTimeout   time.Duration
+	ClientWriteTimeout  time.Duration
+}
+
+// NewForwardingProxy creates new direct TCPProxy, everything will be proxied to
+// localAddr.
+func NewForwardingProxy(localAddr string, logger log.Logger) *ForwardingProxy {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+
+	return &ForwardingProxy{
+		localAddr: localAddr,
+		logger:    logger,
+	}
+}
+
+// NewMultiForwardingProxy creates a new dispatching TCPProxy, connections may go to
+// different backends based on localAddrMap.
+func NewMultiForwardingProxy(localAddrMap map[string]string, logger log.Logger) *ForwardingProxy {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+
+	return &ForwardingProxy{
+		localAddrMap:        localAddrMap,
+		logger:              logger,
+		ForwardingHTTPProxy: NewReverseProxy(),
+		AuthUser:            "",
+		AuthPass:            "",
+		DestDialTimeout:     10 * time.Second,
+		DestReadTimeout:     5 * time.Second,
+		DestWriteTimeout:    5 * time.Second,
+		ClientReadTimeout:   5 * time.Second,
+		ClientWriteTimeout:  5 * time.Second,
+	}
+}
+
+// Proxy is a ProxyFunc.
+func (p *ForwardingProxy) Proxy(w io.Writer, r io.ReadCloser, msg *proto.ControlMessage) {
+	switch msg.ForwardedProto {
+	case proto.HTTPCONNECT:
+		// ok
+	default:
+		p.logger.Log(
+			"level", 0,
+			"msg", "unsupported protocol",
+			"ctrlMsg", msg,
+		)
+		return
+	}
+
+	rw, ok := w.(http.ResponseWriter)
+	if !ok {
+		p.logger.Log(
+			"level", 0,
+			"msg", "expected http.ResponseWriter",
+			"ctrlMsg", msg,
+		)
+	}
+
+	req, err := http.ReadRequest(bufio.NewReader(r))
+	if err != nil {
+		p.logger.Log(
+			"level", 0,
+			"msg", "failed to read request",
+			"ctrlMsg", msg,
+			"err", err,
+		)
+		return
+	}
+	setXForwardedFor(req.Header, msg.RemoteAddr)
+	req.URL.Host = msg.ForwardedHost
+
+	p.ServeHTTP(rw, req, r)
+
+}
+
+func (p *ForwardingProxy) ServeHTTP(w http.ResponseWriter, r *http.Request, rr io.ReadCloser) {
+	p.logger.Log("Incoming request host", r.Host)
+	if p.AuthUser != "" && p.AuthPass != "" {
+		user, pass, ok := parseBasicProxyAuth(r.Header.Get("Proxy-Authorization"))
+		if !ok || user != p.AuthUser || pass != p.AuthPass {
+			//p.Logger.Warn("Authorization attempt with invalid credentials")
+			http.Error(w, http.StatusText(http.StatusProxyAuthRequired), http.StatusProxyAuthRequired)
+			return
+		}
+	}
+	if r.URL.Scheme == "http" {
+		p.ForwardingHTTPProxy.ServeHTTP(w, r)
+	} else {
+		p.handleTunneling(w, r, rr)
+	}
+}
+
+func (p *ForwardingProxy) handleTunneling(w http.ResponseWriter, r *http.Request, rr io.ReadCloser) {
+	if r.Method != http.MethodConnect {
+		//p.Logger.Info("Method not allowed", zap.String("method", r.Method))
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+
+	//p.Logger.Debug("Connecting", zap.String("host", r.Host))
+
+	destConn, err := net.DialTimeout("tcp", r.Host, p.DestDialTimeout)
+	if err != nil {
+		//p.Logger.Error("Destination dial failed", zap.Error(err))
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	now := time.Now()
+	destConn.SetReadDeadline(now.Add(p.DestReadTimeout))
+	destConn.SetWriteDeadline(now.Add(p.DestWriteTimeout))
+
+	//p.Logger.Debug("Connected", zap.String("host", r.Host))
+	fmt.Println("Connected to host", r.Host)
+
+	resp := http.Response{}
+	resp.StatusCode = 200
+	resp.Proto = "HTTP/1.1"
+	resp.ProtoMajor = 1
+	resp.ProtoMinor = 1
+
+	resp.Write(w)
+
+	w.(http.Flusher).Flush()
+
+	fmt.Println("Flushed to host", r.Host)
+
+	done := make(chan struct{})
+	go func() {
+		transfer(flushWriter{w}, destConn, log.NewContext(p.logger).With(
+			// "dst", msg.ForwardedHost,
+			"src", r.Host,
+		))
+		close(done)
+	}()
+
+	transfer(destConn, rr, log.NewContext(p.logger).With(
+		"dst", r.Host,
+		// "src", msg.ForwardedHost,
+	))
+
+	<-done
+
+	fmt.Println("Done for", r.Host)
+	destConn.Close()
+	rr.Close()
+}
+
+// parseBasicProxyAuth parses an HTTP Basic Authorization string.
+// "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==" returns ("Aladdin", "open sesame", true).
+func parseBasicProxyAuth(authz string) (username, password string, ok bool) {
+	const prefix = "Basic "
+	if !strings.HasPrefix(authz, prefix) {
+		return
+	}
+	c, err := base64.StdEncoding.DecodeString(authz[len(prefix):])
+	if err != nil {
+		return
+	}
+	cs := string(c)
+	s := strings.IndexByte(cs, ':')
+	if s < 0 {
+		return
+	}
+	return cs[:s], cs[s+1:], true
+}
+
+// NewReverseProxy retuns a new reverse proxy that takes an incoming
+// request and sends it to another server, proxying the response back to the
+// client.
+//
+// See: https://golang.org/pkg/net/http/httputil/#ReverseProxy
+func NewReverseProxy() *httputil.ReverseProxy {
+	director := func(req *http.Request) {
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to default value
+			req.Header.Set("User-Agent", "")
+		}
+	}
+	// TODO:(alesr) Use timeouts specified via flags to customize the default
+	// transport used by the reverse proxy.
+	return &httputil.ReverseProxy{
+		Director: director,
+	}
+}

--- a/proto/controlmsg.go
+++ b/proto/controlmsg.go
@@ -33,6 +33,8 @@ const (
 	TCP6 = "tcp6"
 	UNIX = "unix"
 	SNI  = "sni"
+
+	HTTPCONNECT = "httpconnect"
 )
 
 // ControlMessage is sent from server to client before streaming data. It's

--- a/proxy.go
+++ b/proxy.go
@@ -20,6 +20,8 @@ type ProxyFuncs struct {
 	HTTP ProxyFunc
 	// TCP is custom implementation of TCP proxing.
 	TCP ProxyFunc
+	// this enables http tunneling
+	HTTPCONNECT ProxyFunc
 }
 
 // Proxy returns a ProxyFunc that uses custom function if provided.
@@ -31,6 +33,8 @@ func Proxy(p ProxyFuncs) ProxyFunc {
 			f = p.HTTP
 		case proto.TCP, proto.TCP4, proto.TCP6, proto.UNIX:
 			f = p.TCP
+		case proto.HTTPCONNECT:
+			f = p.HTTPCONNECT
 		}
 
 		if f == nil {

--- a/server.go
+++ b/server.go
@@ -418,14 +418,32 @@ func (s *Server) addTunnels(tunnels map[string]*proto.Tunnel, identifier id.ID) 
 		Hosts:     []*HostAuth{},
 		Listeners: []net.Listener{},
 	}
-
+	f := make(map[net.Listener]string)
 	var err error
 	for name, t := range tunnels {
 		switch t.Protocol {
 		case proto.HTTP:
 			i.Hosts = append(i.Hosts, &HostAuth{t.Host, NewAuth(t.Auth)})
+		case proto.HTTPCONNECT:
+			var l net.Listener
+
+			l, err = net.Listen(proto.TCP, t.Addr)
+			if err != nil {
+				goto rollback
+			}
+
+			s.logger.Log(
+				"level", 2,
+				"action", "open listener",
+				"identifier", identifier,
+				"addr", l.Addr(),
+			)
+
+			i.Listeners = append(i.Listeners, l)
+			f[l] = proto.HTTPCONNECT
 		case proto.TCP, proto.TCP4, proto.TCP6, proto.UNIX:
 			var l net.Listener
+
 			l, err = net.Listen(t.Protocol, t.Addr)
 			if err != nil {
 				goto rollback
@@ -439,6 +457,7 @@ func (s *Server) addTunnels(tunnels map[string]*proto.Tunnel, identifier id.ID) 
 			)
 
 			i.Listeners = append(i.Listeners, l)
+
 		case proto.SNI:
 			if s.vhostMuxer == nil {
 				err = fmt.Errorf("unable to configure SNI for tunnel %s: %s", name, t.Protocol)
@@ -458,6 +477,7 @@ func (s *Server) addTunnels(tunnels map[string]*proto.Tunnel, identifier id.ID) 
 			)
 
 			i.Listeners = append(i.Listeners, l)
+
 		default:
 			err = fmt.Errorf("unsupported protocol for tunnel %s: %s", name, t.Protocol)
 			goto rollback
@@ -470,9 +490,14 @@ func (s *Server) addTunnels(tunnels map[string]*proto.Tunnel, identifier id.ID) 
 	}
 
 	for _, l := range i.Listeners {
-		go s.listen(l, identifier)
-	}
+		p, ok := f[l]
+		if ok {
+			go s.listenExt(l, identifier, p)
+		} else {
+			go s.listen(l, identifier)
+		}
 
+	}
 	return nil
 
 rollback:
@@ -496,6 +521,10 @@ func (s *Server) Ping(identifier id.ID) (time.Duration, error) {
 }
 
 func (s *Server) listen(l net.Listener, identifier id.ID) {
+	s.listenExt(l, identifier, l.Addr().Network())
+}
+
+func (s *Server) listenExt(l net.Listener, identifier id.ID, fp string) {
 	addr := l.Addr().String()
 
 	for {
@@ -524,7 +553,7 @@ func (s *Server) listen(l net.Listener, identifier id.ID) {
 
 		msg := &proto.ControlMessage{
 			Action:         proto.ActionProxy,
-			ForwardedProto: l.Addr().Network(),
+			ForwardedProto: fp, //,
 		}
 
 		tlsConn, ok := conn.(*vhost.TLSConn)


### PR DESCRIPTION
I did add support for http tunneling with support for http connect.
This involves a new protocol: httpconnect and a new proxy function handling the connect request.
The new function is implemented into the forwardingproxy.go